### PR TITLE
Fix for detecting application/json payloads

### DIFF
--- a/backbone_api_controller.php
+++ b/backbone_api_controller.php
@@ -50,13 +50,13 @@ class BackboneAPIController {
 		// php won't fill out the post array with the vars so we handle it ourselves
 		if ($_SERVER['REQUEST_METHOD'] == 'PUT') {
 			$php_input = file_get_contents("php://input");
-			if ($_SERVER['CONTENT_TYPE'] == 'application/json') {
+			if (strpos($_SERVER['CONTENT_TYPE'],'application/json') !== false) {
 				$this->post = json_decode($php_input, true);
 			} else {
 				parse_str($php_input, $this->post);
 			}
 		} elseif ($_SERVER['REQUEST_METHOD'] == 'POST') {
-			if ($_SERVER['CONTENT_TYPE'] == 'application/json') {
+			if (strpos($_SERVER['CONTENT_TYPE'],'application/json') !== false) {
 				$this->post = json_decode(file_get_contents('php://input'), true);
 			} else {
 				$this->post = $_POST;


### PR DESCRIPTION
Firefox wouldn't allow updates to items.  They would POST ok, but PUTs
would always return a 404.  Reason was chrome was sending the normal
"application/json", but Firefox was sending "application/json;
charset=UTF-8".

This commit looks for the PRESENCE of applicaiton/json in the request
content type instead of the entire content_type being application/json
